### PR TITLE
Add CAP_SYS_MODULE capability

### DIFF
--- a/config.json
+++ b/config.json
@@ -119,7 +119,8 @@
     "linux": {
         "AllowAllDevices": true,
         "capabilities": [
-            "CAP_SYS_ADMIN"
+            "CAP_SYS_ADMIN",
+            "CAP_SYS_MODULE"
         ],
         "devices": null
     },


### PR DESCRIPTION
* the plugin needs this capability when the host does not have
  the `rbd` kernel module loaded. When it tries to map the
  image, `/usr/bin/rbd` will call `modprobe` and fail with
  "Permission denied".