### PR TITLE
Pass the cluster name to rbd invocations.

### DIFF
--- a/lib/rbd-driver-private.go
+++ b/lib/rbd-driver-private.go
@@ -90,7 +90,7 @@ func (d *rbdDriver) removeRbdImage(imageName string) error {
 // rbdsh will call rbd with the given command arguments, also adding config, user and pool flags
 func (d *rbdDriver) rbdsh(command string, args ...string) (string, error) {
 
-	args = append([]string{"--pool", d.conf["pool"], "--name", d.conf["keyring_user"], command}, args...)
+	args = append([]string{"--cluster", d.conf["cluster"], "--pool", d.conf["pool"], "--name", d.conf["keyring_user"], command}, args...)
 
 	return shWithDefaultTimeout("rbd", args...)
 }


### PR DESCRIPTION
This adds support for clusters not named 'ceph' effectively.

Note: I've only been able to test the rbd interactions; I'm still having issues getting the plugin fully working for clusters not named ceph, so there may be more work necessary for that support.