### PR TITLE
Support for rbd namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ RBD_CONF_DEVICE_MAP_ROOT="/dev/rbd"
 RBD_CONF_POOL="ssd"
 RBD_CONF_CLUSTER=ceph
 RBD_CONF_KEYRING_USER=client.admin
+RBD_CONF_NAMESPACE=""
 
 Mount options defaults to "--options=noatime" (extended syntax with no spaces)
 MOUNT_OPTIONS="--options=noatime"
@@ -127,8 +128,14 @@ docker plugin enable wetopi/rbd
 
 ## Known problems:
 
-1. **WHEN** docker plugin remove  + install **THEN** containers running in plugins node lost their volumes
+1. **WHEN** docker plugin remove + install **THEN** containers running in plugins node lost their volumes
   **SOLUTION** restart node (swarm moves containers to another node + restart free up the Rbd mapped + mounted images)
+
+2. **WHEN** using a client scoped to an rbd namespace, you are **THEN** unable to create volumes
+  **SOLUTION** alter the cap of the client to allow it to read the rbd_info object in the pool default namespace
+  ```bash
+ceph auth caps client.docker-rbd mon 'allow profile rbd' osd 'allow r pool rbd object_prefix rbd_info, profile rbd  pool=rbd  namespace=testns'
+```
 
 
 ## Troubleshooting

--- a/config.json
+++ b/config.json
@@ -34,6 +34,12 @@
       ]
     },
     {
+      "name": "RBD_CONF_NAMESPACE",
+      "settable": [
+        "value"
+      ]
+    },
+    {
       "name": "RBD_CONF_CLUSTER",
       "settable": [
         "value"

--- a/lib/configuration.go
+++ b/lib/configuration.go
@@ -14,6 +14,7 @@ func (d *rbdDriver) configure() {
 	d.conf["pool"] = "ssd"
 	d.conf["cluster"] = "ceph"
 	d.conf["device_map_root"] = "/dev/rbd"
+	d.conf["namespace"] = ""
 
 	d.loadEnvironmentRbdConfigVars();
 

--- a/lib/rbd-driver-private.go
+++ b/lib/rbd-driver-private.go
@@ -12,7 +12,7 @@ import (
 func (d *rbdDriver) mapImage(imageName string) error {
 	logrus.Debugf("volume-rbd Name=%s Message=rbd map", imageName)
 
-	_, err := d.rbdsh("map", imageName)
+	_, err := d.rbdsh("map", filepath.Join(d.conf["pool"], d.conf["namespace"], imageName))
 
 	return err
 }
@@ -21,7 +21,7 @@ func (d *rbdDriver) mapImage(imageName string) error {
 func (d *rbdDriver) unmapImage(imageName string) error {
 	logrus.Debugf("volume-rbd Name=%s Message=rbd unmap", imageName)
 
-	_, err := d.rbdsh("unmap", imageName)
+	_, err := d.rbdsh("unmap", filepath.Join(d.conf["pool"], d.conf["namespace"], imageName))
 
 	if err != nil {
 		// NOTE: rbd unmap exits 16 if device is still being used - unlike umount.  try to recover differently in that case

--- a/lib/rbd-driver-public.go
+++ b/lib/rbd-driver-public.go
@@ -85,6 +85,10 @@ func (d *rbdDriver) Connect() error {
 	}
 
 	d.ioctx = ioctx
+	// Setup the namespace for the volumes we are working on
+	// default is ""  as it is the name 'internal' name for image without namespace
+	// Calling ioctx.SetNamespace("") is basically a noop
+	ioctx.SetNamespace(d.conf["namespace"])
 
 	return nil
 }


### PR DESCRIPTION
This patchs adds the necessary bits to enable rbd namespaces while not
breaking the behavior for non namespace configurations.
When creating a token scopped for a namespace, you will need to also
give the token the rights to read the rbd_info in the default namespace,
or else you will be unable to create volumes (while mapping/unmapping
and removing works)

Signed-off-by: Florian Florensa <fflorensa@online.net>